### PR TITLE
Make simulator ready for 4d tuning

### DIFF
--- a/nionswift_plugin/usim/CameraDevice.py
+++ b/nionswift_plugin/usim/CameraDevice.py
@@ -151,7 +151,7 @@ class Camera(camera_base.CameraDevice):
         xdata_buffer = None
         integration_count = self.__integration_count or 1
         for frame_number in range(integration_count):
-            if not self.__has_data_event.wait(self.__exposure * 200):
+            if not self.__has_data_event.wait(self.__exposure * 200) and not self.__thread.is_alive():
                 raise Exception("No simulator thread.")
             self.__has_data_event.clear()
             if xdata_buffer is None:

--- a/nionswift_plugin/usim/CameraDevice.py
+++ b/nionswift_plugin/usim/CameraDevice.py
@@ -125,10 +125,10 @@ class Camera(camera_base.CameraDevice):
         return {
             "x_scale_control": self.camera_type + "_x_scale",
             "x_offset_control": self.camera_type + "_x_offset",
-            "x_units_value": "eV" if self.camera_type == "eels" else "nm",
+            "x_units_value": "eV" if self.camera_type == "eels" else "rad",
             "y_scale_control": self.camera_type + "_y_scale",
             "y_offset_control": self.camera_type + "_y_offset",
-            "y_units_value": "" if self.camera_type == "eels" else "nm",
+            "y_units_value": "" if self.camera_type == "eels" else "rad",
             "intensity_units_value": "counts",
             "counts_per_electron_value": self.__instrument.counts_per_electron
         }

--- a/nionswift_plugin/usim/CameraDevice.py
+++ b/nionswift_plugin/usim/CameraDevice.py
@@ -185,6 +185,7 @@ class Camera(camera_base.CameraDevice):
         self.__is_acquiring = True
         self.__has_data_event.clear()  # ensure any has_data_event is new data
         self.__thread_event.set()
+        self.__instrument.sequence_progress = 0
         try:
             properties = None
             data = None
@@ -208,6 +209,7 @@ class Camera(camera_base.CameraDevice):
                     spatial_properties = properties.get("spatial_calibrations")
                     if spatial_properties is not None:
                         properties["spatial_calibrations"] = spatial_properties[1:]
+                self.__instrument.increment_sequence_progress()
         finally:
             self.__is_acquiring = False
         data_element = dict()

--- a/nionswift_plugin/usim/InstrumentDevice.py
+++ b/nionswift_plugin/usim/InstrumentDevice.py
@@ -543,11 +543,12 @@ class Instrument(stem_controller.STEMController):
             fov_nm = Geometry.FloatSize(full_fov_nm * height / self.__ronchigram_shape.height, full_fov_nm * width / self.__ronchigram_shape.width)
             scale_y = binning_shape[0] * fov_nm[0] / height
             scale_x = binning_shape[1] * fov_nm[1] / width
+            scale_y = scale_x = self.__tv_pixel_angle
             offset_y = -scale_y * height * 0.5
             offset_x = -scale_x * width * 0.5
             dimensional_calibrations = [
-                Calibration.Calibration(offset=offset_y, scale=scale_y, units="nm"),
-                Calibration.Calibration(offset=offset_x, scale=scale_x, units="nm")
+                Calibration.Calibration(offset=offset_y, scale=scale_y, units="rad"),
+                Calibration.Calibration(offset=offset_x, scale=scale_x, units="rad")
             ]
             return dimensional_calibrations
         if camera_type == "eels":

--- a/nionswift_plugin/usim/InstrumentDevice.py
+++ b/nionswift_plugin/usim/InstrumentDevice.py
@@ -356,6 +356,22 @@ class Instrument(stem_controller.STEMController):
         self.live_probe_position = None
         theta = self.__tv_pixel_angle * self.__ronchigram_shape.height / 2  # half angle on camera
         self.__aberrations_controller = AberrationsController(self.__ronchigram_shape[0], self.__ronchigram_shape[1], theta, self.__max_defocus, self.__defocus_m)
+        self.__sequence_progress = 0
+        self.__lock = threading.Lock()
+
+    @property
+    def sequence_progress(self):
+        with self.__lock:
+            return self.__sequence_progress
+
+    @sequence_progress.setter
+    def sequence_progress(self, value):
+        with self.__lock:
+            self.__sequence_progress = value
+
+    def increment_sequence_progress(self):
+        with self.__lock:
+            self.__sequence_progress += 1
 
     def trigger_camera_frame(self) -> None:
         self.__camera_frame_event.set()

--- a/nionswift_plugin/usim/ScanDevice.py
+++ b/nionswift_plugin/usim/ScanDevice.py
@@ -150,7 +150,9 @@ class Device:
                     current_frame.bad = True
                     current_frame.complete = True
                 self.__instrument.live_probe_position = Geometry.FloatPoint(y=y / h, x=x / w)
-                target_count = current_frame.data_count + 1
+                sequence_progress = self.__instrument.sequence_progress
+                target_count = max(sequence_progress - 2*(sequence_progress//(size.width+2) + 1) + 1,
+                                   current_frame.data_count + 1)
             else:
                 pixels_remaining = total_pixels - current_frame.data_count
                 pixel_wait = min(pixels_remaining * frame_parameters.pixel_time_us / 1E6, time_slice)


### PR DESCRIPTION
This change adds the possibility to acquire somewhat realistic 3D and 4D datasets with the ronchigram camera because it uses the "live_probe_position" to shift the ronchigram. I also added some new controls that are needed for the 4d tuning algorithm to run. With this version it is possible to bench-test 4d tuning with the simulator.