### PR TITLE
Allow adding controls to existing instrument. Implemented 2d controls.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog (nionswift-usim)
 ==========================
 
+0.1.8 (unreleased)
+------------------
+
+- Allow adding new controls to existing instrument instance.
+- Add support for 2D controls and AxisManager
+
+
 0.1.7 (2019-04-29)
 ------------------
 


### PR DESCRIPTION
These are quite big changes but they actually make the implementation of `Instrument` simpler and cleaner. You can now add new controls to an existing `Instrument` instance and connect them to built-in controls. There is also support for 2D controls and an axis manager that can convert between different coordinate systems. The current implementation of `AxisManager` does not do any conversions, but everything is prepared for it to do so which should make implementing it straightforward if we need it.
I also added some tests for the new Control/2DControl/AxisManager system.