### PR TITLE
Move synchronization out of instrument and into scan.

### DIFF
--- a/nionswift_plugin/usim/CameraDevice.py
+++ b/nionswift_plugin/usim/CameraDevice.py
@@ -159,6 +159,9 @@ class Camera(camera_base.CameraDevice3):
             "counts_per_electron_value": self.__instrument.counts_per_electron
         }
 
+    def get_dimensional_calibrations(self, readout_area: typing.Optional[Geometry.IntRect], binning_shape: typing.Optional[Geometry.IntSize]) -> typing.Sequence[Calibration.Calibration]:
+        return self.__simulator.get_dimensional_calibrations(readout_area, binning_shape)
+
     def start_live(self) -> None:
         """Start live acquisition. Required before using acquire_image."""
         if not self.__is_playing:

--- a/nionswift_plugin/usim/InstrumentDevice.py
+++ b/nionswift_plugin/usim/InstrumentDevice.py
@@ -777,13 +777,13 @@ class Instrument(stem_controller.STEMController):
             camera_device: typing.Optional[CameraDevice.Camera] = Registry.get_component(f"usim_{p}_camera_device")
             if camera_device:
                 if s == "y_offset":
-                    return True, camera_device.simulator.get_dimensional_calibrations(None, None)[0].offset
+                    return True, camera_device.get_dimensional_calibrations(None, None)[0].offset
                 elif s == "x_offset":
-                    return True, camera_device.simulator.get_dimensional_calibrations(None, None)[1].offset
+                    return True, camera_device.get_dimensional_calibrations(None, None)[1].offset
                 elif s == "y_scale":
-                    return True, camera_device.simulator.get_dimensional_calibrations(None, None)[0].scale
+                    return True, camera_device.get_dimensional_calibrations(None, None)[0].scale
                 elif s == "x_scale":
-                    return True, camera_device.simulator.get_dimensional_calibrations(None, None)[1].scale
+                    return True, camera_device.get_dimensional_calibrations(None, None)[1].scale
             return False, None
 
         if s == "EELS_MagneticShift_Offset":

--- a/nionswift_plugin/usim/InstrumentDevice.py
+++ b/nionswift_plugin/usim/InstrumentDevice.py
@@ -427,10 +427,6 @@ class Instrument(stem_controller.STEMController):
         # We need to set the expressions after adding the controls to InstrumentDevice
         self.__set_expressions()
 
-
-    def close(self) -> None:
-        ...
-
     def _get_config_property(self, name: str) -> typing.Any:
         if name in ("stage_size_nm", "max_defocus"):
             return getattr(self, name)

--- a/nionswift_plugin/usim/ScanDevice.py
+++ b/nionswift_plugin/usim/ScanDevice.py
@@ -277,7 +277,7 @@ class Device:
         frame_parameters = current_frame.frame_parameters
         size = Geometry.IntSize.make(frame_parameters.subscan_pixel_size if frame_parameters.subscan_pixel_size else frame_parameters.size)
         total_pixels = size.height * size.width
-        time_slice = 0.05  # 50 ms
+        time_slice = 0.005  # 5 ms
 
         if current_frame.scan_data is None:
             scan_data = list()

--- a/nionswift_plugin/usim/ScanDevice.py
+++ b/nionswift_plugin/usim/ScanDevice.py
@@ -51,9 +51,8 @@ class Frame:
 
 class ScanBoxSimulator:
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.__blanker_signal_condition = threading.Condition()
-        # self.__pixel_advance_condition = threading.Condition()
         self.__advance_pixel_lock = threading.RLock()
         self.__current_pixel_flat = 0
         self.__scan_shape_pixels = Geometry.IntSize()
@@ -67,7 +66,7 @@ class ScanBoxSimulator:
         return self.__scan_shape_pixels
 
     @scan_shape_pixels.setter
-    def scan_shape_pixels(self, shape: typing.Union[Geometry.IntSize, Geometry.SizeIntTuple]):
+    def scan_shape_pixels(self, shape: typing.Union[Geometry.IntSize, Geometry.SizeIntTuple]) -> None:
         self.__scan_shape_pixels = Geometry.IntSize.make(shape)
         with self.__advance_pixel_lock:
             self.__current_pixel_flat = 0
@@ -77,7 +76,7 @@ class ScanBoxSimulator:
         return self.__pixel_size_nm
 
     @pixel_size_nm.setter
-    def pixel_size_nm(self, size: typing.Union[Geometry.FloatSize, Geometry.SizeFloatTuple]):
+    def pixel_size_nm(self, size: typing.Union[Geometry.FloatSize, Geometry.SizeFloatTuple]) -> None:
         self.__pixel_size_nm = Geometry.FloatSize.make(size)
         with self.__advance_pixel_lock:
             self.__current_pixel_flat = 0
@@ -395,8 +394,9 @@ class Device:
         self.__frame_number += 1
         self.__frame = Frame(self.__frame_number, channels, frame_parameters)
         self.__scan_box.scan_shape_pixels = size
-        self.__scan_box.pixel_size_nm = Geometry.FloatSize(frame_parameters.fov_size_nm.height / size.height,
-                                                          frame_parameters.fov_size_nm.width / size.width)
+        if frame_parameters.fov_size_nm is not None:
+            self.__scan_box.pixel_size_nm = Geometry.FloatSize(frame_parameters.fov_size_nm.height / size.height,
+                                                               frame_parameters.fov_size_nm.width / size.width)
         self.__scan_box.external_clock = self.__frame_parameters.external_clock_mode != 0
         self.__is_scanning = True
 

--- a/nionswift_plugin/usim/test/Camera_test.py
+++ b/nionswift_plugin/usim/test/Camera_test.py
@@ -1,4 +1,7 @@
 import unittest
+import threading
+import time
+
 
 from nion.instrumentation.test import CameraControl_test
 
@@ -32,6 +35,42 @@ class TestCamera(CameraControl_test.TestCameraControlClass):
             self._acquire_one(document_controller, hardware_source)
             self._acquire_one(document_controller, hardware_source)
             self.assertEqual(len(document_model.data_items[0].xdata.data_shape), 1)
+
+    def test_camera_waits_for_external_trigger(self) -> None:
+        for external_trigger in [False, True]:
+            with self.subTest(external_trigger=external_trigger):
+                with self._test_context(is_eels=True) as test_context:
+                    document_controller = test_context.document_controller
+                    document_model = test_context.document_model
+                    hardware_source = test_context.camera_hardware_source
+                    scan = test_context.scan_hardware_source
+                    frame_parameters = hardware_source.get_frame_parameters(0)
+                    frame_parameters.binning = 1
+                    frame_parameters.processing = "sum_project"
+                    frame_parameters.exposure_ms = 100
+                    hardware_source.set_current_frame_parameters(frame_parameters)
+                    hardware_source.camera._external_trigger = external_trigger
+                    sequence_data_elements = None
+                    sequence_time = 0
+                    camera_event = threading.Event()
+                    def acquire():
+                        nonlocal sequence_data_elements, sequence_time
+                        starttime = time.time()
+                        sequence_data_elements = hardware_source.acquire_sequence(10)
+                        sequence_time = time.time() - starttime
+                        camera_event.set()
+                    scan_frame_parameters = scan.get_frame_parameters(0)
+                    scan_frame_parameters.size = (1, 10)
+                    scan_frame_parameters.pixel_time_us = 100000
+                    scan.set_current_frame_parameters(scan_frame_parameters)
+                    threading.Thread(target=acquire).start()
+                    time.sleep(3)
+                    xdata_list = scan.record_immediate(scan_frame_parameters)
+                    self.assertTrue(camera_event.wait(10))
+                    if external_trigger:
+                        self.assertGreater(sequence_time, 3.0)
+                    else:
+                        self.assertLess(sequence_time, 3.0)
 
 
 if __name__ == '__main__':

--- a/nionswift_plugin/usim/test/Camera_test.py
+++ b/nionswift_plugin/usim/test/Camera_test.py
@@ -51,9 +51,9 @@ class TestCamera(CameraControl_test.TestCameraControlClass):
                     hardware_source.set_current_frame_parameters(frame_parameters)
                     hardware_source.camera._external_trigger = external_trigger
                     sequence_data_elements = None
-                    sequence_time = 0
+                    sequence_time = 0.
                     camera_event = threading.Event()
-                    def acquire():
+                    def acquire() -> None:
                         nonlocal sequence_data_elements, sequence_time
                         starttime = time.time()
                         sequence_data_elements = hardware_source.acquire_sequence(10)

--- a/nionswift_plugin/usim/test/InstrumentDevice_test.py
+++ b/nionswift_plugin/usim/test/InstrumentDevice_test.py
@@ -30,6 +30,7 @@ def measure_thickness(d: _NDArray) -> float:
     return math.log(sum(d) / s)
 
 def create_camera_and_scan_simulator(instrument: InstrumentDevice.Instrument, camera_type: str) -> typing.Tuple[CameraSimulator.CameraSimulator, ScanDevice.Device]:
+    camera_simulator: CameraSimulator.CameraSimulator
     if camera_type == "eels":
         camera_simulator = EELSCameraSimulator.EELSCameraSimulator(instrument, Geometry.IntSize.make(instrument.camera_sensor_dimensions("eels")), instrument.counts_per_electron)
     else:


### PR DESCRIPTION
This is the first chunk of changes. It removes synchronization between scan and cameras from the instrument and uses a new "scan box simulator" that simulates the behavior of hardware connections on real devices.
All instrumentation-kit tests except for one also pass with the patch submitted in instrumentation-kit. The failing test fails on this line: https://github.com/nion-software/nionswift-instrumentation-kit/blob/b2745d38e97f1c459750c0c347c4741d890f439f/nion/instrumentation/test/ScanControl_test.py#L446
I wasn't able to figure out why this fails now...if you add a ``scan_hardware_source.get_next_xdatas_to_start()`` after ``scan_hardware_source.start_playing()`` it passes.