### PR TITLE
Device modes

### DIFF
--- a/nionswift_plugin/usim/CameraDevice.py
+++ b/nionswift_plugin/usim/CameraDevice.py
@@ -283,7 +283,6 @@ class Camera(camera_base.CameraDevice3):
         # if the device does not implement acquire_sequence, fall back to looping acquisition.
         self.__is_acquiring = True
         self.__has_data_event.clear()  # ensure any has_data_event is new data
-        self.__instrument.sequence_progress = 0
         try:
             properties = None
             data = None

--- a/nionswift_plugin/usim/CameraDevice.py
+++ b/nionswift_plugin/usim/CameraDevice.py
@@ -268,7 +268,6 @@ class Camera(camera_base.CameraDevice3):
                     spatial_properties = properties.get("spatial_calibrations")
                     if spatial_properties is not None:
                         properties["spatial_calibrations"] = spatial_properties[1:]
-                self.__instrument.increment_sequence_progress()
         finally:
             self.__is_acquiring = False
         data_element = dict()
@@ -392,7 +391,7 @@ class CameraTask:
         n = min(max(int(update_period / exposure), 1), self.__count - start)
         is_complete = start + n == self.__count
         # print(f"{start=} {n=} {self.__count=} {is_complete=}")
-        data_element = self.__camera_device._acquire_sequence((n))
+        data_element = self.__camera_device._acquire_sequence(n)
         if data_element and not self.__aborted:
             xdata = ImportExportManager.convert_data_element_to_data_and_metadata(data_element)
             dimensional_calibrations = tuple(Calibration.Calibration() for _ in range(len(self.__collection_shape))) + tuple(xdata.dimensional_calibrations[1:])

--- a/nionswift_plugin/usim/InstrumentDevice.py
+++ b/nionswift_plugin/usim/InstrumentDevice.py
@@ -418,7 +418,6 @@ class Instrument(stem_controller.STEMController):
         self.__live_probe_position: typing.Optional[Geometry.FloatPoint] = None
         self.__sequence_progress = 0
         self._is_synchronized = False
-        self.__lock = threading.Lock()
         self.__controls: typing.Dict[str, typing.Union[Control2D, Variable]] = dict()
 
         built_in_controls = self.__create_built_in_controls()
@@ -612,20 +611,6 @@ class Instrument(stem_controller.STEMController):
         if isinstance(weight, Variable):
             return weight.output_value
         return weight
-
-    @property
-    def sequence_progress(self) -> int:
-        with self.__lock:
-            return self.__sequence_progress
-
-    @sequence_progress.setter
-    def sequence_progress(self, value: int) -> None:
-        with self.__lock:
-            self.__sequence_progress = value
-
-    def increment_sequence_progress(self) -> None:
-        with self.__lock:
-            self.__sequence_progress += 1
 
     def _enter_synchronized_state(self, scan_controller: HardwareSource.HardwareSource, *, camera: typing.Optional[HardwareSource.HardwareSource] = None) -> None:
         self._is_synchronized = True

--- a/nionswift_plugin/usim/InstrumentDevice.py
+++ b/nionswift_plugin/usim/InstrumentDevice.py
@@ -416,7 +416,6 @@ class Instrument(stem_controller.STEMController):
         self.__scan_context = stem_controller.ScanContext()
         self.__probe_position: typing.Optional[Geometry.FloatPoint] = None
         self.__live_probe_position: typing.Optional[Geometry.FloatPoint] = None
-        self.__sequence_progress = 0
         self._is_synchronized = False
         self.__controls: typing.Dict[str, typing.Union[Control2D, Variable]] = dict()
 


### PR DESCRIPTION
So this is a first attempt at the "burst mode" for the simulator cameras. This is stilla work-in-progress as we have to settle on how to implement it exactly.
There are also still some timing problems which is why the test for the new mode needs to use a much smaller pixel time for the camera than for the scan (https://github.com/Brow71189/nionswift-usim/blob/5cb5a6f6296b3fc1157c5c20d61d20ebc8e76086/nionswift_plugin/usim/test/Camera_test.py#L88, scan pixel time defined in line 108).
I think the reason for this is that we are not handling the flyback time correctly. Essentially the simulator always uses two flyback pixels but it doesn't actually add any extra time for them in free running mode. The correct behavior would be to not have flyback pixels in free running mode but instead just add a short wait time when advancing to the next line (although I don't know how to implement that correctly, since these times are on the order of a couple of 100 us). Maybe we can just have longer ones in the simulator which probably doens't hurt but makes this synchronized burst mode more reliable.